### PR TITLE
DECEiFER fixes

### DIFF
--- a/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
+++ b/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
@@ -216,8 +216,8 @@ class RenewHookController extends BasePermissionController
                 // There was no scheduled transfer tracked. This is all good.
             }
         } elseif ($renewal_action == 'enable') {
-            $this->add_todo('The autorenewal for ' . $domain->domain . ' has been enabled. Reschedule the transfer with Openprovider.',
-                'Reschedule the transfer in case this domain was supposed to get transferred.');
+            /*$this->add_todo('The autorenewal for ' . $domain->domain . ' has been enabled. Reschedule the transfer with Openprovider.',
+                'Reschedule the transfer in case this domain was supposed to get transferred.');*/
         }
 
         return true;

--- a/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
+++ b/modules/addons/openprovider/Controllers/Hooks/RenewHookController.php
@@ -62,11 +62,12 @@ class RenewHookController extends BasePermissionController
     {
         // Get the domain details
         $domain = $this->capsule->table('tbldomains')
-            ->find($params['params']['domainid']);
-
+        ->find($params['params']['domainid']);
         if ($this->checkIsNotOpenprovider($domain) == false) // It is an openprovider domain. Skip this one.
         {
-            return true;
+            return array (
+                'abortWithSuccess' => true,
+            );
         }
 
         // Check if the domain is scheduled for a transfer.
@@ -92,7 +93,7 @@ class RenewHookController extends BasePermissionController
             try {
                 $openprovider_domain = $this->openProvider->api->modifyScheduledTransferDate($openprovider_api_domain, date("Y-m-d H:i:s"));
             } catch (\Exception $ex) {
-                return false;
+                return array();
             }
 
             return array (
@@ -100,7 +101,7 @@ class RenewHookController extends BasePermissionController
             );
         }
 
-        return false;
+        return array();
     }
 
     /**

--- a/modules/registrars/openprovider/OpenProvider/API/CustomerAddress.php
+++ b/modules/registrars/openprovider/OpenProvider/API/CustomerAddress.php
@@ -36,13 +36,13 @@ class CustomerAddress extends \OpenProvider\API\AutoloadConstructor
         try {
             $splitAddress = AddressSplitter::splitAddress($fullAddress);
             $housenumber = $splitAddress['houseNumberParts']['base'];
-            $convertedAddress = $splitAddress['streetName'] . ' ' . $splitAddress['additionToAddress2'];
+            $convertedAddress = $splitAddress['streetName'] . ($splitAddress['additionToAddress2'] ? " {$splitAddress['additionToAddress2']}" : "");
 
             $this->street   =   $convertedAddress;
             $this->number   =   $housenumber;
         } catch (\Exception $e)
         {
-            if (strpos($e->getMessage(), ' could not be splitted into street name and house number.') !== false)
+            if (strpos($e->getMessage(), ' could not be split into street name and house number.') !== false)
                 $this->street = $fullAddress;
             else
                 throw $e;

--- a/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Crypt.php
+++ b/modules/registrars/openprovider/OpenProvider/WhmcsHelpers/Crypt.php
@@ -18,16 +18,20 @@ class Crypt
 	 **/
 	public static function decrypt($encrypted_string)
 	{
-		$command 	= 'DecryptPassword';
-	    $postData 	= array(
-	        'password2' => $encrypted_string,
-	    );
+		if (function_exists('\decrypt')){
+			return \decrypt($encrypted_string);
+		} else{
+			$command 	= 'DecryptPassword';
+			$postData 	= array(
+				'password2' => $encrypted_string,
+			);
 
-	    $admin_user = General::get_admin_user();
+			$admin_user = General::get_admin_user();
 
-	    $results = localAPI($command, $postData, $admin_user);
+			$results = localAPI($command, $postData, $admin_user);
 
-	    return $results['password'];
+			return $results['password'];
+		}
 	}
 
 	/**
@@ -38,16 +42,20 @@ class Crypt
 	 **/
 	public static function encrypt($decrypted_string)
 	{
-		$command 	= 'EncryptPassword';
-	    $postData 	= array(
-	        'password2' => $decrypted_string,
-	    );
+		if (function_exists('\encrypt')){
+			return \encrypt($decrypted_string);
+		} else{
+			$command 	= 'EncryptPassword';
+			$postData 	= array(
+				'password2' => $decrypted_string,
+			);
 
-        $admin_user = General::get_admin_user();
+			$admin_user = General::get_admin_user();
 
-	    $results = localAPI($command, $postData, $admin_user);
-	    
-	    return $results['password'];
+			$results = localAPI($command, $postData, $admin_user);
+
+			return $results['password'];
+		}
 	}
 
 } // END class Crypt

--- a/modules/registrars/openprovider/src/Configuration.php
+++ b/modules/registrars/openprovider/src/Configuration.php
@@ -76,7 +76,13 @@ class Configuration
 
     public static function getServerUrl()
     {
-        $systemUrl = localAPI(WHMCSApiActionType::GetConfigurationValue, ['setting' => 'SystemURL'])['value'];
+        if (method_exists('\\WHMCS\\Config\\Setting', 'getValue')){
+            $systemUrl = rtrim(\WHMCS\Config\Setting::getValue('SystemURL'), '/') . "/";
+        }
+
+        if (!isset($systemUrl)){
+            $systemUrl = rtrim(\localAPI(WHMCSApiActionType::GetConfigurationValue, ['setting' => 'SystemURL'])['value']) . "/";
+        }
 
         $systemUrlWithoutProtocol = str_replace(['http://', 'https://'], '', $systemUrl);
         $phpHostUrl = $_SERVER['HTTP_HOST'];


### PR DESCRIPTION
Incorporation of changes committed by [DECEIFER](https://github.com/subedinfo-it/Openprovider-WHMCS-domains/compare/master...DECEiFER:Openprovider-WHMCS-domains:master)

>[Update CustomerAddress.php](https://github.com/subedinfo-it/Openprovider-WHMCS-domains/commit/30ccc97bbaa642da45765c0c6da1a13f07105d96) 
> Get rid of trailing space at the end of the $convertedAddress when no additionToAddress2 is set.
>
> Spelling correction on "splitted" to "split."

> [Update Configuration.php](https://github.com/subedinfo-it/Openprovider-WHMCS-domains/commit/20829d94cd3a5c4011a8a07677673c725f0679cb) 
> Remove the need for a localAPI HTTP request to get the system URL if the Settings class and getValue method exists and use the localAPI call as a fallback. For consistency, rtrim the trailing slash and append it.

> [Update Crypt.php](https://github.com/subedinfo-it/Openprovider-WHMCS-domains/commit/fc2cc95aa90e7041d48f440ae26a87943f5cbe3f) 
> Remove the need for a localAPI HTTP request encode/encrypt and decode/decrypt data, but keep it as a fallback in case WHMCS changes their core encrypt and decrypt function names or access.

> [Update RenewHookController.php](https://github.com/subedinfo-it/Openprovider-WHMCS-domains/commit/3102f300205915296efacc9b2a305a8abe339686) 
> Prevent PHP 8.x TypeError by returning a boolean from processRenewal() - return an array.

> [Update RenewHookController.php](https://github.com/subedinfo-it/Openprovider-WHMCS-domains/commit/2542832ce96bd805605a8852ff8656ac78f789a5) 
> Please reevaluate the autorenew enabled todo addition. It's really not necessary and clogs up the todo list, as it happens EVERY time a non-Openprover domain is edited.
